### PR TITLE
record: support the optional weight field

### DIFF
--- a/records.go
+++ b/records.go
@@ -2,6 +2,7 @@ package dnspod
 
 import (
 	"fmt"
+	"strconv"
 )
 
 const (
@@ -28,6 +29,7 @@ type Record struct {
 	Remark        string `json:"remark,omitempty"`
 	UpdateOn      string `json:"updated_on,omitempty"`
 	UseAQB        string `json:"use_aqb,omitempty"`
+	Weight        *int   `json:"weight,omitempty"`
 }
 
 type recordsWrapper struct {
@@ -112,6 +114,10 @@ func (s *RecordsService) Create(domain string, recordAttributes Record) (Record,
 		payload.Add("status", recordAttributes.Status)
 	}
 
+	if recordAttributes.Weight != nil {
+		payload.Add("weight", strconv.Itoa(*recordAttributes.Weight))
+	}
+
 	returnedRecord := recordWrapper{}
 
 	res, err := s.client.post(methodRecordCreate, payload, &returnedRecord)
@@ -185,6 +191,10 @@ func (s *RecordsService) Update(domain string, recordID string, recordAttributes
 
 	if recordAttributes.Status != "" {
 		payload.Add("status", recordAttributes.Status)
+	}
+
+	if recordAttributes.Weight != nil {
+		payload.Add("weight", strconv.Itoa(*recordAttributes.Weight))
 	}
 
 	returnedRecord := recordWrapper{}


### PR DESCRIPTION
`weight` 在企业 VPN 域名记录中会存在。

```
权重信息，0到100的整数。仅企业 VIP 域名可用，0 表示关闭，留空或者不传该参数，表示不设置权重信息。
```

可能的值：

- `null` (default)
- `int` if presents

参考：https://docs.dnspod.cn/api/5f5629e9e75cf42d25bf6864/ 